### PR TITLE
Hotfix: npm cli broken image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![NPM Version](https://img.shields.io/badge/npm-v0.1.0-orange)
 ![License Status](https://img.shields.io/badge/license-MIT-blue)
 
-![create-project CLI](https://github.com/jorenrui/create-project/blob/master/assets/cli.png)
+![create-project CLI](https://raw.githubusercontent.com/jorenrui/create-project/HEAD/assets/cli.png)
 
 ## Features
 


### PR DESCRIPTION
# Story Title

[Bug: npm cli broken image link](https://github.com/jorenrui/create-project/issues/22)

## Changes made

- Updated the CLI image link to `https://raw.githubusercontent.com/jorenrui/create-project/HEAD/assets/cli.png`

## Linked issues

Resolves #22
